### PR TITLE
Fix mismatch info

### DIFF
--- a/threejs/threejs-multiple-scenes-controls.html
+++ b/threejs/threejs-multiple-scenes-controls.html
@@ -82,7 +82,7 @@ function main() {
       const intensity = 1;
       const light = new THREE.DirectionalLight(color, intensity);
       light.position.set(-1, 2, 4);
-      scene.add(light);
+      camera.add(light);
     }
 
     return {scene, camera, controls};


### PR DESCRIPTION
light should be added to `camera` not `scene`