### PR TITLE
Improve diff of code snippet example

### DIFF
--- a/threejs/lessons/threejs-scenegraph.md
+++ b/threejs/lessons/threejs-scenegraph.md
@@ -209,6 +209,7 @@ Continuing that same pattern let's add a moon.
 
 const earthMaterial = new THREE.MeshPhongMaterial({color: 0x2233FF, emissive: 0x112244});
 const earthMesh = new THREE.Mesh(sphereGeometry, earthMaterial);
+-earthMesh.position.x = 10; // note that this offset is already set in its parent's THREE.Object3D object "earthOrbit"
 -solarSystem.add(earthMesh);
 +earthOrbit.add(earthMesh);
 objects.push(earthMesh);


### PR DESCRIPTION
I coded / copy pasted along the code snippets and it took me a while to realize, that I have to remove `earthMesh.position.x = 10;` as the offset is already set in its parent's `earthOrbit`-_THREE.Object3D_-object. Before that example this line was already present.

Thanks again for the great tutorials! :) 