### PR TITLE
Update threejs-backgrounds.md

### DIFF
--- a/threejs/lessons/ja/threejs-backgrounds.md
+++ b/threejs/lessons/ja/threejs-backgrounds.md
@@ -219,7 +219,7 @@ const camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
 +    () => {
 +      const rt = new THREE.WebGLCubeRenderTarget(texture.image.height);
 +      rt.fromEquirectangularTexture(renderer, texture);
-+      scene.background = rt;
++      scene.background = rt.texture;
 +    });
 }
 ```

--- a/threejs/lessons/kr/threejs-backgrounds.md
+++ b/threejs/lessons/kr/threejs-backgrounds.md
@@ -222,7 +222,7 @@ const camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
 +    () => {
 +      const rt = new THREE.WebGLCubeRenderTarget(texture.image.height);
 +      rt.fromEquirectangularTexture(renderer, texture);
-+      scene.background = rt;
++      scene.background = rt.texture;
 +    });
 }
 ```

--- a/threejs/lessons/threejs-backgrounds.md
+++ b/threejs/lessons/threejs-backgrounds.md
@@ -235,7 +235,7 @@ Passing in the height of the equirectangular image seems like a good bet.
 +    () => {
 +      const rt = new THREE.WebGLCubeRenderTarget(texture.image.height);
 +      rt.fromEquirectangularTexture(renderer, texture);
-+      scene.background = rt;
++      scene.background = rt.texture;
 +    });
 }
 ```

--- a/threejs/threejs-background-equirectangularmap.html
+++ b/threejs/threejs-background-equirectangularmap.html
@@ -78,7 +78,7 @@ function main() {
       () => {
         const rt = new THREE.WebGLCubeRenderTarget(texture.image.height);
         rt.fromEquirectangularTexture(renderer, texture);
-        scene.background = rt;
+        scene.background = rt.texture;
       });
   }
 


### PR DESCRIPTION


WebGLBackground: Remove support for WebGLCubeRenderTarget.

> r127

https://github.com/mrdoob/three.js/commit/de40fd3dad7480befa171227860d946a3c5e9224



<br>

**so...**

* threejs-backgrounds.md
* threejs-background-equirectangularmap.html

```diff
-	scene.background = rt;
+	scene.background = rt.texture;
```

