### PR TITLE
HD-DPI updates for 2-scenes-examples in Cameras tutorial

### DIFF
--- a/threejs/threejs-cameras-orthographic-2-scenes.html
+++ b/threejs/threejs-cameras-orthographic-2-scenes.html
@@ -157,8 +157,11 @@ function main() {
 
   function resizeRendererToDisplaySize(renderer) {
     const canvas = renderer.domElement;
-    const width = canvas.clientWidth;
-    const height = canvas.clientHeight;
+
+    // Retrieve the device pixel ratio and apply to the renderer size
+    const pixelRatio = window.devicePixelRatio;
+    const width = canvas.clientWidth * pixelRatio;
+    const height = canvas.clientHeight * pixelRatio;
     const needResize = canvas.width !== width || canvas.height !== height;
     if (needResize) {
       renderer.setSize(width, height, false);
@@ -181,8 +184,11 @@ function main() {
 
     // setup the scissor to only render to that part of the canvas
     const positiveYUpBottom = canvasRect.height - bottom;
-    renderer.setScissor(left, positiveYUpBottom, width, height);
-    renderer.setViewport(left, positiveYUpBottom, width, height);
+
+    // Retrieve the device pixel ratio and apply to the scissor and view port
+    const pixelRatio = window.devicePixelRatio;
+    renderer.setScissor(left * pixelRatio, positiveYUpBottom * pixelRatio, width * pixelRatio, height * pixelRatio);
+    renderer.setViewport(left * pixelRatio, positiveYUpBottom * pixelRatio, width * pixelRatio, height * pixelRatio);
 
     // return the aspect
     return width / height;

--- a/threejs/threejs-cameras-perspective-2-scenes.html
+++ b/threejs/threejs-cameras-perspective-2-scenes.html
@@ -157,8 +157,11 @@ function main() {
 
   function resizeRendererToDisplaySize(renderer) {
     const canvas = renderer.domElement;
-    const width = canvas.clientWidth;
-    const height = canvas.clientHeight;
+
+    // Retrieve the device pixel ratio and apply to the renderer size
+    const pixelRatio = window.devicePixelRatio;
+    const width = canvas.clientWidth * pixelRatio;
+    const height = canvas.clientHeight * pixelRatio;
     const needResize = canvas.width !== width || canvas.height !== height;
     if (needResize) {
       renderer.setSize(width, height, false);
@@ -181,8 +184,11 @@ function main() {
 
     // setup the scissor to only render to that part of the canvas
     const positiveYUpBottom = canvasRect.height - bottom;
-    renderer.setScissor(left, positiveYUpBottom, width, height);
-    renderer.setViewport(left, positiveYUpBottom, width, height);
+
+    // Retrieve the device pixel ratio and apply to the scissor and view port
+    const pixelRatio = window.devicePixelRatio;
+    renderer.setScissor(left * pixelRatio, positiveYUpBottom * pixelRatio, width * pixelRatio, height * pixelRatio);
+    renderer.setViewport(left * pixelRatio, positiveYUpBottom * pixelRatio, width * pixelRatio, height * pixelRatio);
 
     // return the aspect
     return width / height;


### PR DESCRIPTION
### Summary Of Changes

This PR updates two examples source code in "Cameras" tutorial, in order to support HD-DPI displays.

### Background
I was following the tutorial from the beginning, even through "[Responsive Design](https://threejsfundamentals.org/threejs/lessons/threejs-responsive.html)" section.
I was hand writing the tutorial code one by one, with no copy and paste, and that got me have responsible version of `resizeRendererToDisplaySize()` until I I reached to "[Camera](https://threejsfundamentals.org/threejs/lessons/threejs-cameras.html)" section.
And I found out that the examples didn't appear correctly in term of render area on my display like the screenshot below.
![image](https://user-images.githubusercontent.com/78368735/119161542-70916600-ba27-11eb-8b61-e5820aff2d4c.png)
I guess that it was because my display's pixel ratio was bigger than 1, so I came to write the PR.

Also, I am willing to help to rewrite the whole examples to consider the client's display DPI. 😃 

As a 3.js developer, I really appreciate your such historical efforts including ones on [webGL fundamentals](https://webglfundamentals.org/) 🍻 .

### Testing Notes
N/A

### Deployment Notes
- [ ] New Dependencies
- [ ] New Migrations

Closes #N/A